### PR TITLE
Added support for FKeys when switching gametabs

### DIFF
--- a/osr/interfaces/gametabs.simba
+++ b/osr/interfaces/gametabs.simba
@@ -17,36 +17,46 @@ type
   );
 
   TRSGametab = record
-    tabs: TBoxArray;
+    Tabs: TBoxArray;
+    Keybindings: TIntegerArray;
+    FKeysEnabled: Boolean;
   end;
 
-  
+
   TGtButton = record
     stateEnabled: UInt32;
     stateDisabled: UInt32;
     bounds: TBox;
   end;
-  
+
 var
   Gametabs: TRSGametab;
-  
+
 procedure TRSGametab.__setup();
-var 
+var
   Upper,Lower:TBox;
 begin
   with Self do
   begin
     Upper := [527,168,760,204];
     Lower := [527,466,760,502];
-    
-    tabs := Upper.Partition(1, 7, -3);
-    tabs.Extend(Lower.Partition(1, 7, -3));
+
+    Tabs := Upper.Partition(1, 7, -3);
+    Tabs.Extend(Lower.Partition(1, 7, -3));
+
+    Keybindings := [VK_F1, VK_F2, VK_F3, VK_ESCAPE, VK_F4, VK_F5, VK_F6, VK_F7,
+                    VK_F8, VK_F9, 0, VK_F10, VK_F11, VK_F12];
   end;
+end;
+
+procedure TRSGametab.ToggleFKeys(const Enable:Boolean);
+begin
+  Self.FKeysEnabled := Enable;
 end;
 
 function TRSGametab.GetBounds(Tab:EGametab): TBox;
 begin
-  Result := Self.tabs[Ord(Tab)];
+  Result := Self.Tabs[Ord(Tab)];
 end;
 
 function TRSGametab.IsOpen(Tab:EGametab; maxWait:Int32=0): Boolean;
@@ -61,8 +71,8 @@ begin
     else if (Tab = tabInventory) then //when in bank no tabs exist
     begin
       FoundTab := False;
-      for i:=0 to High(Self.tabs) do
-        if (CountColorTolerance(1910383, Self.tabs[i], 13) > 0) then
+      for i:=0 to High(Self.Tabs) do
+        if (CountColorTolerance(1910383, Self.Tabs[i], 13) > 0) then
         begin
           FoundTab := True;
           break;
@@ -86,12 +96,17 @@ begin
 
   for i:=1 to tries do
   begin
-    Mouse.Click(B, 1);
-    t := GetTickCount64() + Random(1500,2500);
-    repeat
-      if self.IsOpen(Tab) then
+    if (Self.FKeysEnabled and (Keybindings[Ord(tab)] <> 0)) then
+    begin
+      Keyboard.PressKey(Keybindings[Ord(tab)]);
+      if self.IsOpen(Tab, Random(1500,2500)) then
         Exit(True);
-    until (GetTickCount64() > t);
+      Self.ToggleFKeys(False);
+    end;
+
+    Mouse.Click(B, 1);
+    if self.IsOpen(Tab, Random(1500,2500)) then
+      Exit(True);
   end;
 end;
 
@@ -134,7 +149,7 @@ begin
 end;
 
 
-//Checks if the given button (by bounds) is red/enabled 
+//Checks if the given button (by bounds) is red/enabled
 function TGtButton.IsEnabled(): Boolean;
 begin
   Result := CountColorTolerance(self.stateEnabled, self.bounds, 30) > 70;


### PR DESCRIPTION
Requires the default keybinding setup.
FKey:Boolean defaults to false. It's a completely optional functionality.
