### PR TITLE
Added support for FKey when closing the bankscreen

### DIFF
--- a/osr/interfaces/bankscreen.simba
+++ b/osr/interfaces/bankscreen.simba
@@ -254,15 +254,24 @@ begin
   if (not Self.IsOpen()) then
     Exit(True);
 
-  Self.ClickButton(bbClose);
+  if (srl.CloseInterfacesWithEscape) then
+  begin
+    Keyboard.PressKey(VK_ESCAPE);
+    t := GetTickCount64() + Random(4000, 5000);
+    while (t > GetTickCount64()) do
+    begin
+      if (not Self.IsOpen()) then
+        Exit(True);
+    end;
+    srl.ToggleCloseInterfacesWithEscape(False);
+  end;
 
+  Self.ClickButton(bbClose);
   t := GetTickCount64() + Random(4000, 5000);
   while (t > GetTickCount64()) do
   begin
     if (not Self.IsOpen()) then
       Exit(True);
-
-    Wait(Random(100, 200));
   end;
 end;
 

--- a/shared/srl.simba
+++ b/shared/srl.simba
@@ -15,6 +15,8 @@ type
 
     OnLoginPlayer: procedure();
     OnLoginResponse: function(Response: String): Boolean;
+
+    CloseInterfacesWithEscape: Boolean;
  end;
 
 var
@@ -76,6 +78,11 @@ end;
 procedure TSRL.WriteFmt(Str: String; Args: TVariantArray; debugType: EDebugType = dtNone);
 begin
   Self.WriteLn(Format(Str, Args), debugType);
+end;
+
+procedure TSRL.ToggleCloseInterfacesWithEscape(Enable: Boolean);
+begin
+  Self.CloseInterfacesWithEscape := Enable;
 end;
 
 procedure TSRL.Setup(Options: ESRLOptions = [srlDebug]);


### PR DESCRIPTION
Requires the default keybinding setup with the "Esc closes current interface" checkbox ticked (bottom left corner).
![alt text](http://i.imgur.com/xhmGTi9.png)

FKey:Boolean defaults to false. It's a completely optional functionality.
