### PR TITLE
Bug fix for TTimeMarker in time.simba

### DIFF
--- a/shared/time.simba
+++ b/shared/time.simba
@@ -168,8 +168,7 @@ Example:
 *)
 procedure TTimeMarker.Start();
 begin
-  if (Self.FStartTime = 0) then
-    Self.FPrevMark := GetTickCount(); // used for adding time after a pause
+  Self.FPrevMark := GetTickCount(); // used for adding time after a pause
 
   if (not Self.FPaused) and (Self.FStartTime = 0) then
   begin


### PR DESCRIPTION
The if statement on line 171 was preventing the TTimeMarker from setting FPrevMark to the tick count in TTimeMarker.Start() when the timer was resumed from a paused state. This causes TTimeMarker.GetTime() to return an incorrect value after the TTimeMarker is started again from pause because it uses FPrevMark to calculate the time since the Start() function was last called.