### PR TITLE
Update IsOpen and Close in ChooseOption.simba

### DIFF
--- a/osr/chooseoption.simba
+++ b/osr/chooseoption.simba
@@ -412,8 +412,8 @@ begin
   
   //if option box is flush to the left of client and taller than 500px set move direction to the right
   if (B.X1 < 15) and ((B.Y2 - B.Y1) > 500) then
-    dir.T := Random(Tan(-((B.Y2 - 20) - pt.Y) / (B.X2 - pt.x)),
-                    Tan(-((B.Y1 + 20) - pt.Y) / (B.X2 - pt.x)));
+    dir.T := Random(Arctan((B.Y1 - pt.Y) / ((B.X2 + 20) - pt.x)),
+                    Arctan((B.Y2 - pt.Y) / ((B.X2 + 20) - pt.x)));
                     
   try
     Mouse.Move(pt.x+Round(300*Cos(dir.T)), pt.y+Round(300*Sin(dir.T)));

--- a/osr/chooseoption.simba
+++ b/osr/chooseoption.simba
@@ -121,9 +121,8 @@ Checks if the menu is open, it repeats the check for a +/-2 sec if it's ``False`
 .. note:: by slacky
 *)
 function TRSChooseOption.IsOpen(tryTime:Int32=-1): Boolean;
-var _:TPoint;
 begin
-  Result := self.__find(_, tryTime);
+  Result := self.Find(tryTime);
 end;
 
 (*
@@ -409,7 +408,13 @@ begin
   if dir.R > Abs(pt.x - B.x2) then dir := [Abs(pt.x - B.x2), 0];
   if dir.R > Abs(pt.y - B.y2) then dir := [Abs(pt.y - B.y2), (Pi/2)];
   
-  dir.T := (dir.T-Pi/3) + Random()*((dir.T+Pi/3) - (dir.T-Pi/3));
+  dir.T := (dir.T-Pi/3) + Random()*(2*Pi/3);
+  
+  //if option box is flush to the left of client and taller than 500px set move direction to the right
+  if (B.X1 < 15) and ((B.Y2 - B.Y1) > 500) then
+    dir.T := Random(Tan(-((B.Y2 - 20) - pt.Y) / (B.X2 - pt.x)),
+                    Tan(-((B.Y1 + 20) - pt.Y) / (B.X2 - pt.x)));
+                    
   try
     Mouse.Move(pt.x+Round(300*Cos(dir.T)), pt.y+Round(300*Sin(dir.T)));
     self.Select(['Cancel']);


### PR DESCRIPTION
Changed "IsOpen" to use "Find" instead of "__Find" so that the option box boundaries will be set after "IsOpen" is called. I don't think this should cause issues since "Find" has a call to the other "__Find" function inside of it.

In "Close" function I simplified the expression on line 412 of original to the equivalent expression: (dir.T-Pi/3) + Random()*(2*Pi/3);
In "Close" function, I also added a piece of code to detect when the option box is within a few pixels of the left boundary of the client and over 500 pixels tall. If the option box is all the way to the left, you can not clear it by moving the mouse that direction, and if the option box is taller than 500 pixels it usually means the "Cancel" option has been bumped off the bottom, so the only way to clear it is to move the mouse to the right. This code snippet will force the move direction to an angle between the top right corner and bottom right corner of the option box, when the previous conditions are detected.