### PR TITLE
Client.simba was unable to find the lobby screen. 

### DIFF
--- a/osr/client.simba
+++ b/osr/client.simba
@@ -44,7 +44,7 @@ begin
     Exit(True);
 
   // LOBBY: `Never` in `Never tell anybody your password...`
-  if (csLobby in States) and FindText('Never', [141, 106, 172, 115], $00FFFF, 'SmallChars07') then
+  if (csLobby in States) and (GetColor(400, 400) = 0) then
     Exit(True);
 end;
 


### PR DESCRIPTION
Lobby.IsOpen always resulted to false for me when sitting in the lobby. I changed it from looking for text to looking for the black background of the lobby screen.

Signed-off-by: Dark_Sniper